### PR TITLE
Add reusable error schemas and Gin middleware patterns example

### DIFF
--- a/examples/gin-integration/main.go
+++ b/examples/gin-integration/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/picogrid/go-op"
+	goop "github.com/picogrid/go-op"
 	"github.com/picogrid/go-op/operations"
 	ginadapter "github.com/picogrid/go-op/operations/adapters/gin"
 	"github.com/picogrid/go-op/validators"
@@ -22,7 +22,7 @@ import (
 // 3. Type-safe validation with automatic OpenAPI generation
 // 4. Migration patterns from manual validation to go-op schemas
 
-// Domain models matching an existing system (e.g., Legion Platform)
+// Domain models matching an existing system (e.g., Platform Platform)
 type User struct {
 	ID        uuid.UUID `json:"id"`
 	Email     string    `json:"email"`
@@ -52,7 +52,7 @@ type PaginatedResponse[T any] struct {
 	Paging     map[string]interface{} `json:"paging"`
 }
 
-// Simulated service layer (like Legion's container pattern)
+// Simulated service layer (like Platform's container pattern)
 type UserService struct {
 	// In real app: database, cache, etc.
 }

--- a/examples/gin-middleware-patterns/main.go
+++ b/examples/gin-middleware-patterns/main.go
@@ -1,0 +1,553 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/picogrid/go-op/operations"
+	ginadapter "github.com/picogrid/go-op/operations/adapters/gin"
+	"github.com/picogrid/go-op/validators"
+)
+
+// This example demonstrates comprehensive middleware patterns with go-op and Gin
+// It shows both global middleware (applied to all routes) and per-operation middleware
+// using the new WithMiddleware functionality.
+
+// Domain models
+type User struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Role  string `json:"role"` // "user", "admin", "super_admin"
+}
+
+type Company struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Settings struct {
+	NotificationsEnabled bool              `json:"notifications_enabled"`
+	Theme                string            `json:"theme"`
+	Preferences          map[string]string `json:"preferences"`
+}
+
+// Request/Response types
+type CreateSettingsRequest struct {
+	NotificationsEnabled bool              `json:"notifications_enabled"`
+	Theme                string            `json:"theme"`
+	Preferences          map[string]string `json:"preferences,omitempty"`
+}
+
+type SettingsResponse struct {
+	ID        string    `json:"id"`
+	CompanyID string    `json:"company_id"`
+	UserID    string    `json:"user_id"`
+	Settings  Settings  `json:"settings"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Global middleware - applied to all routes
+func RequestLoggingMiddleware() gin.HandlerFunc {
+	return gin.LoggerWithConfig(gin.LoggerConfig{
+		SkipPaths: []string{"/health", "/metrics"},
+	})
+}
+
+func CORSMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Access-Control-Allow-Origin", "*")
+		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-COMPANY-ID")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func SecurityHeadersMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("X-XSS-Protection", "1; mode=block")
+		c.Next()
+	}
+}
+
+// Authentication middleware - validates JWT tokens
+func RequireJWTAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Missing authorization header",
+				"code":  "AUTH_MISSING",
+			})
+			c.Abort()
+			return
+		}
+
+		// Simple Bearer token validation (in real app, validate JWT)
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Invalid authorization format",
+				"code":  "AUTH_INVALID_FORMAT",
+			})
+			c.Abort()
+			return
+		}
+
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+
+		// Simulate JWT validation and user extraction
+		var user User
+		switch token {
+		case "user_token":
+			user = User{ID: "usr_123", Email: "user@example.com", Role: "user"}
+		case "admin_token":
+			user = User{ID: "usr_456", Email: "admin@example.com", Role: "admin"}
+		case "super_admin_token":
+			user = User{ID: "usr_789", Email: "super@example.com", Role: "super_admin"}
+		default:
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Invalid or expired token",
+				"code":  "AUTH_INVALID_TOKEN",
+			})
+			c.Abort()
+			return
+		}
+
+		// Store user in context for downstream handlers
+		c.Set("user", user)
+		c.Set("user_id", user.ID)
+		c.Next()
+	}
+}
+
+// Company context middleware - extracts company ID from header
+func RequireCompanyID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		companyID := c.GetHeader("X-COMPANY-ID")
+		if companyID == "" {
+			// Also check query parameter as fallback
+			companyID = c.Query("company_id")
+		}
+
+		if companyID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Company ID is required",
+				"code":  "COMPANY_ID_MISSING",
+			})
+			c.Abort()
+			return
+		}
+
+		// Validate company ID format (UUID)
+		if _, err := uuid.Parse(companyID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Invalid company ID format",
+				"code":  "COMPANY_ID_INVALID",
+			})
+			c.Abort()
+			return
+		}
+
+		// Simulate company validation and storage
+		company := Company{
+			ID:   companyID,
+			Name: fmt.Sprintf("Company %s", companyID[:8]),
+		}
+
+		c.Set("company", company)
+		c.Set("company_id", companyID)
+		c.Next()
+	}
+}
+
+// Role-based access control middleware
+func RequireRole(allowedRoles ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userInterface, exists := c.Get("user")
+		if !exists {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "User context not found",
+				"code":  "USER_CONTEXT_MISSING",
+			})
+			c.Abort()
+			return
+		}
+
+		user, ok := userInterface.(User)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Invalid user context",
+				"code":  "USER_CONTEXT_INVALID",
+			})
+			c.Abort()
+			return
+		}
+
+		// Check if user has any of the allowed roles
+		hasRole := false
+		for _, role := range allowedRoles {
+			if user.Role == role {
+				hasRole = true
+				break
+			}
+		}
+
+		if !hasRole {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": fmt.Sprintf("Insufficient permissions. Required roles: %v, user role: %s", allowedRoles, user.Role),
+				"code":  "INSUFFICIENT_PERMISSIONS",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// Scope-based access control middleware (similar to your RequireOrgScopes)
+func RequireScopes(requiredScopes []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userInterface, exists := c.Get("user")
+		if !exists {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "User context not found",
+				"code":  "USER_CONTEXT_MISSING",
+			})
+			c.Abort()
+			return
+		}
+
+		user := userInterface.(User)
+
+		// Simulate scope resolution based on user role and org
+		var userScopes []string
+		switch user.Role {
+		case "user":
+			userScopes = []string{"settings:read"}
+		case "admin":
+			userScopes = []string{"settings:read", "settings:write", "users:read"}
+		case "super_admin":
+			userScopes = []string{"settings:read", "settings:write", "users:read", "users:write", "admin:all"}
+		}
+
+		// Check if user has all required scopes
+		hasAllScopes := true
+		missingScopes := []string{}
+
+		for _, required := range requiredScopes {
+			hasScope := false
+			for _, userScope := range userScopes {
+				if userScope == required || userScope == "admin:all" {
+					hasScope = true
+					break
+				}
+			}
+			if !hasScope {
+				hasAllScopes = false
+				missingScopes = append(missingScopes, required)
+			}
+		}
+
+		if !hasAllScopes {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":       "Insufficient scopes",
+				"code":        "INSUFFICIENT_SCOPES",
+				"required":    requiredScopes,
+				"missing":     missingScopes,
+				"user_scopes": userScopes,
+			})
+			c.Abort()
+			return
+		}
+
+		// Store validated scopes for downstream use
+		c.Set("validated_scopes", requiredScopes)
+		c.Next()
+	}
+}
+
+// Rate limiting middleware (simple version)
+func RateLimitMiddleware() gin.HandlerFunc {
+	// In real app, use redis or similar for distributed rate limiting
+	return func(c *gin.Context) {
+		// Simulate rate limiting check
+		c.Header("X-RateLimit-Remaining", "99")
+		c.Header("X-RateLimit-Reset", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()))
+		c.Next()
+	}
+}
+
+// Business logic handlers (pure functions - no HTTP concerns)
+func getSettingsHandler(ctx context.Context, params struct{}, query struct{}, body struct{}) (SettingsResponse, error) {
+	// Simulate database lookup
+	return SettingsResponse{
+		ID:        "set_" + uuid.New().String()[:8],
+		CompanyID: "comp_123",
+		UserID:    "usr_123",
+		Settings: Settings{
+			NotificationsEnabled: true,
+			Theme:                "dark",
+			Preferences: map[string]string{
+				"language": "en",
+				"timezone": "UTC",
+			},
+		},
+		CreatedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func createSettingsHandler(ctx context.Context, params struct{}, query struct{}, body CreateSettingsRequest) (SettingsResponse, error) {
+	// Simulate settings creation
+	return SettingsResponse{
+		ID:        "set_" + uuid.New().String()[:8],
+		CompanyID: "comp_123",
+		UserID:    "usr_123",
+		Settings:  Settings(body),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+func getUserInfoHandler(ctx context.Context, params struct{}, query struct{}, body struct{}) (User, error) {
+	// This would typically get user from context or database
+	return User{
+		ID:    "usr_123",
+		Email: "user@example.com",
+		Role:  "admin",
+	}, nil
+}
+
+// Gin handler adapters that extract context and call business logic
+func ginGetSettings(c *gin.Context) {
+	result, err := getSettingsHandler(c.Request.Context(), struct{}{}, struct{}{}, struct{}{})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func ginCreateSettings(c *gin.Context) {
+	var req CreateSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	result, err := createSettingsHandler(c.Request.Context(), struct{}{}, struct{}{}, req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+func ginGetUserInfo(c *gin.Context) {
+	result, err := getUserInfoHandler(c.Request.Context(), struct{}{}, struct{}{}, struct{}{})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func main() {
+	// Create Gin engine
+	engine := gin.New()
+
+	// Apply global middleware using GetEngine().Use() pattern
+	engine.Use(gin.Recovery())
+	engine.Use(RequestLoggingMiddleware())
+	engine.Use(CORSMiddleware())
+	engine.Use(SecurityHeadersMiddleware())
+	engine.Use(RateLimitMiddleware())
+
+	// Global auth middleware - all routes require authentication
+	engine.Use(RequireJWTAuth())
+
+	// Global org context - all routes require company ID
+	engine.Use(RequireCompanyID())
+
+	// Create OpenAPI generator
+	openAPIGen := operations.NewOpenAPIGenerator("Middleware Patterns API", "1.0.0")
+	openAPIGen.SetDescription("Comprehensive example of middleware patterns with go-op and Gin")
+
+	// Create go-op router
+	router := ginadapter.NewGinRouter(engine, openAPIGen)
+
+	// Define schemas for validation and OpenAPI generation
+	createSettingsSchema := validators.Object(map[string]interface{}{
+		"notifications_enabled": validators.Bool().Required(),
+		"theme": validators.String().
+			Pattern("^(light|dark|auto)$").
+			Required(),
+		"preferences": validators.Object(map[string]interface{}{}).
+			Optional(),
+	}).Required()
+
+	settingsResponseSchema := validators.Object(map[string]interface{}{
+		"id":         validators.String().Required(),
+		"company_id": validators.String().Required(),
+		"user_id":    validators.String().Required(),
+		"settings": validators.Object(map[string]interface{}{
+			"notifications_enabled": validators.Bool().Required(),
+			"theme":                 validators.String().Required(),
+			"preferences":           validators.Object(map[string]interface{}{}).Required(),
+		}).Required(),
+		"created_at": validators.String().Required(),
+		"updated_at": validators.String().Required(),
+	}).Required()
+
+	userResponseSchema := validators.Object(map[string]interface{}{
+		"id":    validators.String().Required(),
+		"email": validators.String().Email().Required(),
+		"role":  validators.String().Required(),
+	}).Required()
+
+	// Define operations with per-operation middleware using WithMiddleware
+
+	// 1. Get settings - requires read scope only
+	getSettingsOp := operations.NewSimple().
+		GET("/api/v1/settings").
+		Summary("Get application settings").
+		Description("Retrieves settings for the current company").
+		Tags("Settings").
+		WithResponse(settingsResponseSchema).
+		Handler(router.WithMiddleware(
+			ginGetSettings,
+			RequireScopes([]string{"settings:read"}),
+		))
+
+	// 2. Create settings - requires write scope and admin role
+	createSettingsOp := operations.NewSimple().
+		POST("/api/v1/settings").
+		Summary("Create application settings").
+		Description("Creates new settings for the current company").
+		Tags("Settings").
+		WithBody(createSettingsSchema).
+		WithResponse(settingsResponseSchema).
+		Handler(router.WithMiddleware(
+			ginCreateSettings,
+			RequireRole("admin", "super_admin"),       // Must be admin or super_admin
+			RequireScopes([]string{"settings:write"}), // Must have write scope
+		))
+
+	// 3. Get user info - public endpoint (only needs basic auth from global middleware)
+	getUserInfoOp := operations.NewSimple().
+		GET("/v1/user/me").
+		Summary("Get current user information").
+		Description("Returns information about the currently authenticated user").
+		Tags("User").
+		WithResponse(userResponseSchema).
+		Handler(ginGetUserInfo) // No additional middleware - global auth is sufficient
+
+	// 4. Admin-only endpoint - requires super admin role
+	adminOnlyOp := operations.NewSimple().
+		GET("/v1/admin/status").
+		Summary("Get admin status").
+		Description("Admin-only endpoint for system status").
+		Tags("Admin").
+		WithResponse(validators.Object(map[string]interface{}{
+			"status": validators.String().Required(),
+			"uptime": validators.String().Required(),
+		}).Required()).
+		Handler(router.WithMiddleware(
+			func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{
+					"status": "healthy",
+					"uptime": "24h",
+				})
+			},
+			RequireRole("super_admin"), // Only super admins can access
+		))
+
+	// Register all operations
+	// Register all operations using variadic Register method
+	router.Register(
+		getSettingsOp,
+		createSettingsOp,
+		getUserInfoOp,
+		adminOnlyOp,
+	)
+
+	// Health check endpoint (traditional Gin - no go-op)
+	engine.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status":    "healthy",
+			"timestamp": time.Now().Format(time.RFC3339),
+			"service":   "middleware-patterns-example",
+		})
+	})
+
+	// OpenAPI spec endpoint
+	engine.GET("/openapi.json", router.ServeSpec(openAPIGen))
+
+	// Documentation endpoint
+	engine.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"service": "Middleware Patterns Example",
+			"patterns": gin.H{
+				"global_middleware": []string{
+					"Recovery", "Logging", "CORS", "Security Headers",
+					"Rate Limiting", "JWT Auth", "Org Context",
+				},
+				"per_operation_middleware": []string{
+					"Role-based Access Control", "Scope-based Access Control",
+				},
+			},
+			"endpoints": gin.H{
+				"health":     "GET /health",
+				"openapi":    "GET /openapi.json",
+				"settings":   "GET /api/v1/settings (scope: settings:read)",
+				"create":     "POST /api/v1/settings (role: admin+, scope: settings:write)",
+				"user_info":  "GET /v1/user/me (basic auth only)",
+				"admin_only": "GET /v1/admin/status (role: super_admin)",
+			},
+			"test_tokens": gin.H{
+				"user":        "user_token",
+				"admin":       "admin_token",
+				"super_admin": "super_admin_token",
+			},
+		})
+	})
+
+	fmt.Println("🚀 Middleware Patterns Example starting on :8080")
+	fmt.Println()
+	fmt.Println("📝 Example demonstrates:")
+	fmt.Println("  • Global middleware with engine.Use() for all routes")
+	fmt.Println("  • Per-operation middleware with router.WithMiddleware()")
+	fmt.Println("  • Role-based and scope-based access control")
+	fmt.Println("  • Integration with go-op validation and OpenAPI generation")
+	fmt.Println()
+	fmt.Println("🔗 Available endpoints:")
+	fmt.Println("  • GET  /                     - API documentation")
+	fmt.Println("  • GET  /health               - Health check")
+	fmt.Println("  • GET  /openapi.json         - OpenAPI specification")
+	fmt.Println("  • GET  /api/v1/settings    - Get settings (scope: settings:read)")
+	fmt.Println("  • POST /api/v1/settings    - Create settings (role: admin+, scope: settings:write)")
+	fmt.Println("  • GET  /v1/user/me           - User info (basic auth)")
+	fmt.Println("  • GET  /v1/admin/status      - Admin status (role: super_admin)")
+	fmt.Println()
+	fmt.Println("🔑 Test with different tokens:")
+	fmt.Println("  curl -H 'Authorization: Bearer user_token' -H 'X-COMPANY-ID: 550e8400-e29b-41d4-a716-446655440000' http://localhost:8080/v1/user/me")
+	fmt.Println("  curl -H 'Authorization: Bearer admin_token' -H 'X-COMPANY-ID: 550e8400-e29b-41d4-a716-446655440000' http://localhost:8080/api/v1/settings")
+	fmt.Println("  curl -H 'Authorization: Bearer super_admin_token' -H 'X-COMPANY-ID: 550e8400-e29b-41d4-a716-446655440000' http://localhost:8080/v1/admin/status")
+
+	engine.Run(":8080")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.24
 
 require (
 	github.com/gin-gonic/gin v1.10.1
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -13,13 +15,13 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/internal/generator/ast_analyzer.go
+++ b/internal/generator/ast_analyzer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strconv"
 	"strings"
 )
 
@@ -371,7 +372,7 @@ func (a *ASTAnalyzer) extractStringLiteral(expr ast.Expr) string {
 func (a *ASTAnalyzer) extractIntLiteral(expr ast.Expr) int {
 	if basicLit, ok := expr.(*ast.BasicLit); ok && basicLit.Kind == token.INT {
 		var value int
-		fmt.Sscanf(basicLit.Value, "%d", &value)
+		value, _ = strconv.Atoi(basicLit.Value)
 		return value
 	}
 	return 0

--- a/operations/adapters/gin/middleware_test.go
+++ b/operations/adapters/gin/middleware_test.go
@@ -1,0 +1,140 @@
+package gin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		middleware     []GinHandler
+		shouldAbort    bool
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "no middleware",
+			middleware:     []GinHandler{},
+			shouldAbort:    false,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"message":"handler executed"}`,
+		},
+		{
+			name: "middleware that continues",
+			middleware: []GinHandler{
+				func(c *gin.Context) {
+					c.Set("middleware1", "executed")
+					c.Next()
+				},
+				func(c *gin.Context) {
+					c.Set("middleware2", "executed")
+					c.Next()
+				},
+			},
+			shouldAbort:    false,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"message":"handler executed","middleware1":"executed","middleware2":"executed"}`,
+		},
+		{
+			name: "middleware that aborts",
+			middleware: []GinHandler{
+				func(c *gin.Context) {
+					c.Set("middleware1", "executed")
+					c.Next()
+				},
+				func(c *gin.Context) {
+					c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+					c.Abort()
+				},
+			},
+			shouldAbort:    true,
+			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   `{"error":"unauthorized"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test handler that uses context values set by middleware
+			testHandler := func(c *gin.Context) {
+				response := gin.H{"message": "handler executed"}
+
+				// Add any values set by middleware to the response
+				if val, exists := c.Get("middleware1"); exists {
+					response["middleware1"] = val
+				}
+				if val, exists := c.Get("middleware2"); exists {
+					response["middleware2"] = val
+				}
+
+				c.JSON(http.StatusOK, response)
+			}
+
+			// Create router and setup
+			engine := gin.New()
+			router := NewGinRouter(engine)
+
+			// Apply WithMiddleware
+			finalHandler := router.WithMiddleware(testHandler, tt.middleware...)
+
+			// Register the handler
+			engine.GET("/test", finalHandler)
+
+			// Create test request
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/test", nil)
+			engine.ServeHTTP(w, req)
+
+			// Assert results
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.JSONEq(t, tt.expectedBody, w.Body.String())
+		})
+	}
+}
+
+func TestWithMiddleware_OrderMatters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Test that middleware executes in the correct order
+	var executionOrder []string
+
+	middleware1 := func(c *gin.Context) {
+		executionOrder = append(executionOrder, "middleware1")
+		c.Next()
+	}
+
+	middleware2 := func(c *gin.Context) {
+		executionOrder = append(executionOrder, "middleware2")
+		c.Next()
+	}
+
+	testHandler := func(c *gin.Context) {
+		executionOrder = append(executionOrder, "handler")
+		c.JSON(http.StatusOK, gin.H{"execution_order": executionOrder})
+	}
+
+	// Create router and setup
+	engine := gin.New()
+	router := NewGinRouter(engine)
+
+	// Apply WithMiddleware with specific order
+	finalHandler := router.WithMiddleware(testHandler, middleware1, middleware2)
+	engine.GET("/test", finalHandler)
+
+	// Create test request
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	engine.ServeHTTP(w, req)
+
+	// Assert execution order
+	assert.Equal(t, http.StatusOK, w.Code)
+	expected := []string{"middleware1", "middleware2", "handler"}
+	assert.Equal(t, expected, executionOrder)
+}

--- a/operations/adapters/gin/middleware_test.go
+++ b/operations/adapters/gin/middleware_test.go
@@ -138,3 +138,169 @@ func TestWithMiddleware_OrderMatters(t *testing.T) {
 	expected := []string{"middleware1", "middleware2", "handler"}
 	assert.Equal(t, expected, executionOrder)
 }
+
+func TestMiddlewareErrorHandling(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Test middleware that returns different error responses
+	tests := []struct {
+		name           string
+		middleware     GinHandler
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name: "unauthorized middleware",
+			middleware: func(c *gin.Context) {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"error":   "unauthorized",
+					"message": "Authentication is required to access this resource",
+					"code":    401,
+				})
+				c.Abort()
+			},
+			expectedStatus: http.StatusUnauthorized,
+			expectedError:  "unauthorized",
+		},
+		{
+			name: "forbidden middleware",
+			middleware: func(c *gin.Context) {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error":   "forbidden",
+					"message": "You do not have permission to access this resource",
+					"code":    403,
+				})
+				c.Abort()
+			},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "forbidden",
+		},
+		{
+			name: "rate limit middleware",
+			middleware: func(c *gin.Context) {
+				c.JSON(http.StatusTooManyRequests, gin.H{
+					"error":   "too_many_requests",
+					"message": "Too many requests sent in a given amount of time",
+					"code":    429,
+					"details": "Rate limit exceeded. Please try again in 60 seconds",
+				})
+				c.Abort()
+			},
+			expectedStatus: http.StatusTooManyRequests,
+			expectedError:  "too_many_requests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Handler that should not be reached
+			testHandler := func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "handler should not execute"})
+			}
+
+			// Create router and setup
+			engine := gin.New()
+			router := NewGinRouter(engine)
+
+			// Apply middleware that should abort
+			finalHandler := router.WithMiddleware(testHandler, tt.middleware)
+			engine.GET("/test", finalHandler)
+
+			// Create test request
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/test", nil)
+			engine.ServeHTTP(w, req)
+
+			// Assert error response
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.expectedError)
+		})
+	}
+}
+
+func TestAuthenticationMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Mock authentication middleware that validates tokens
+	authMiddleware := func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "Authentication is required to access this resource",
+				"code":    401,
+				"details": "Missing Authorization header",
+			})
+			c.Abort()
+			return
+		}
+		if token != "Bearer valid-token" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "Authentication is required to access this resource",
+				"code":    401,
+				"details": "Invalid or expired authentication token",
+			})
+			c.Abort()
+			return
+		}
+		// Set user context for authorized requests
+		c.Set("user_id", "usr_123")
+		c.Next()
+	}
+
+	// Protected handler
+	protectedHandler := func(c *gin.Context) {
+		userID, _ := c.Get("user_id")
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Protected resource accessed",
+			"user_id": userID,
+		})
+	}
+
+	// Create router
+	engine := gin.New()
+	router := NewGinRouter(engine)
+	finalHandler := router.WithMiddleware(protectedHandler, authMiddleware)
+	engine.GET("/protected", finalHandler)
+
+	tests := []struct {
+		name           string
+		token          string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "no token",
+			token:          "",
+			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   "Missing Authorization header",
+		},
+		{
+			name:           "invalid token",
+			token:          "Bearer invalid-token",
+			expectedStatus: http.StatusUnauthorized,
+			expectedBody:   "Invalid or expired authentication token",
+		},
+		{
+			name:           "valid token",
+			token:          "Bearer valid-token",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "Protected resource accessed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/protected", nil)
+			if tt.token != "" {
+				req.Header.Set("Authorization", tt.token)
+			}
+			engine.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.expectedBody)
+		})
+	}
+}

--- a/operations/adapters/gin/types.go
+++ b/operations/adapters/gin/types.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"github.com/gin-gonic/gin"
+
 	goop "github.com/picogrid/go-op"
 )
 

--- a/operations/error_schemas.go
+++ b/operations/error_schemas.go
@@ -1,0 +1,294 @@
+package operations
+
+import (
+	goop "github.com/picogrid/go-op"
+	"github.com/picogrid/go-op/validators"
+)
+
+// StandardErrorResponse represents a standard API error response
+type StandardErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Code    int    `json:"code,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
+// ValidationErrorResponse represents a validation error with field details
+type ValidationErrorResponse struct {
+	Error   string            `json:"error"`
+	Message string            `json:"message"`
+	Code    int               `json:"code,omitempty"`
+	Fields  map[string]string `json:"fields,omitempty"`
+}
+
+// Common error response schemas that can be reused across operations
+var (
+	// BadRequestErrorSchema represents a 400 Bad Request response
+	BadRequestErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("bad_request").
+			Required(),
+		"message": validators.String().
+			Example("The request could not be understood or was missing required parameters").
+			Required(),
+		"code": validators.Number().
+			Example(400).
+			Optional(),
+		"details": validators.String().
+			Example("Invalid JSON format in request body").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "bad_request",
+		"message": "The request could not be understood or was missing required parameters",
+		"code":    400,
+		"details": "Invalid JSON format in request body",
+	}).Required()
+
+	// ValidationErrorSchema represents a 400 Bad Request with validation errors
+	ValidationErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("validation_failed").
+			Required(),
+		"message": validators.String().
+			Example("Request validation failed").
+			Required(),
+		"code": validators.Number().
+			Example(400).
+			Optional(),
+		"fields": validators.Object(map[string]interface{}{
+			"email": validators.String().Optional(),
+			"age":   validators.String().Optional(),
+		}).
+			Example(map[string]interface{}{
+				"email": "Invalid email format",
+				"age":   "Age must be between 13 and 120",
+			}).
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "validation_failed",
+		"message": "Request validation failed",
+		"code":    400,
+		"fields": map[string]interface{}{
+			"email": "Invalid email format",
+			"age":   "Age must be between 13 and 120",
+		},
+	}).Required()
+
+	// UnauthorizedErrorSchema represents a 401 Unauthorized response
+	UnauthorizedErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("unauthorized").
+			Required(),
+		"message": validators.String().
+			Example("Authentication is required to access this resource").
+			Required(),
+		"code": validators.Number().
+			Example(401).
+			Optional(),
+		"details": validators.String().
+			Example("Invalid or expired authentication token").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "unauthorized",
+		"message": "Authentication is required to access this resource",
+		"code":    401,
+		"details": "Invalid or expired authentication token",
+	}).Required()
+
+	// ForbiddenErrorSchema represents a 403 Forbidden response
+	ForbiddenErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("forbidden").
+			Required(),
+		"message": validators.String().
+			Example("You do not have permission to access this resource").
+			Required(),
+		"code": validators.Number().
+			Example(403).
+			Optional(),
+		"details": validators.String().
+			Example("Insufficient privileges for this operation").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "forbidden",
+		"message": "You do not have permission to access this resource",
+		"code":    403,
+		"details": "Insufficient privileges for this operation",
+	}).Required()
+
+	// NotFoundErrorSchema represents a 404 Not Found response
+	NotFoundErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("not_found").
+			Required(),
+		"message": validators.String().
+			Example("The requested resource was not found").
+			Required(),
+		"code": validators.Number().
+			Example(404).
+			Optional(),
+		"details": validators.String().
+			Example("User with ID 'usr_123' does not exist").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "not_found",
+		"message": "The requested resource was not found",
+		"code":    404,
+		"details": "User with ID 'usr_123' does not exist",
+	}).Required()
+
+	// ConflictErrorSchema represents a 409 Conflict response
+	ConflictErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("conflict").
+			Required(),
+		"message": validators.String().
+			Example("The request conflicts with the current state of the resource").
+			Required(),
+		"code": validators.Number().
+			Example(409).
+			Optional(),
+		"details": validators.String().
+			Example("A user with this email already exists").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "conflict",
+		"message": "The request conflicts with the current state of the resource",
+		"code":    409,
+		"details": "A user with this email already exists",
+	}).Required()
+
+	// UnprocessableEntityErrorSchema represents a 422 Unprocessable Entity response
+	UnprocessableEntityErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("unprocessable_entity").
+			Required(),
+		"message": validators.String().
+			Example("The request was well-formed but contains semantic errors").
+			Required(),
+		"code": validators.Number().
+			Example(422).
+			Optional(),
+		"details": validators.String().
+			Example("Cannot create user: business rules violation").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "unprocessable_entity",
+		"message": "The request was well-formed but contains semantic errors",
+		"code":    422,
+		"details": "Cannot create user: business rules violation",
+	}).Required()
+
+	// TooManyRequestsErrorSchema represents a 429 Too Many Requests response
+	TooManyRequestsErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("too_many_requests").
+			Required(),
+		"message": validators.String().
+			Example("Too many requests sent in a given amount of time").
+			Required(),
+		"code": validators.Number().
+			Example(429).
+			Optional(),
+		"details": validators.String().
+			Example("Rate limit exceeded. Please try again in 60 seconds").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "too_many_requests",
+		"message": "Too many requests sent in a given amount of time",
+		"code":    429,
+		"details": "Rate limit exceeded. Please try again in 60 seconds",
+	}).Required()
+
+	// InternalServerErrorSchema represents a 500 Internal Server Error response
+	InternalServerErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("internal_server_error").
+			Required(),
+		"message": validators.String().
+			Example("An unexpected error occurred on the server").
+			Required(),
+		"code": validators.Number().
+			Example(500).
+			Optional(),
+		"details": validators.String().
+			Example("Database connection failed").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "internal_server_error",
+		"message": "An unexpected error occurred on the server",
+		"code":    500,
+		"details": "Database connection failed",
+	}).Required()
+
+	// BadGatewayErrorSchema represents a 502 Bad Gateway response
+	BadGatewayErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("bad_gateway").
+			Required(),
+		"message": validators.String().
+			Example("Bad gateway - upstream service is unavailable").
+			Required(),
+		"code": validators.Number().
+			Example(502).
+			Optional(),
+		"details": validators.String().
+			Example("Unable to connect to authentication service").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "bad_gateway",
+		"message": "Bad gateway - upstream service is unavailable",
+		"code":    502,
+		"details": "Unable to connect to authentication service",
+	}).Required()
+
+	// ServiceUnavailableErrorSchema represents a 503 Service Unavailable response
+	ServiceUnavailableErrorSchema = validators.Object(map[string]interface{}{
+		"error": validators.String().
+			Example("service_unavailable").
+			Required(),
+		"message": validators.String().
+			Example("The service is temporarily unavailable").
+			Required(),
+		"code": validators.Number().
+			Example(503).
+			Optional(),
+		"details": validators.String().
+			Example("Service is under maintenance. Please try again later").
+			Optional(),
+	}).Example(map[string]interface{}{
+		"error":   "service_unavailable",
+		"message": "The service is temporarily unavailable",
+		"code":    503,
+		"details": "Service is under maintenance. Please try again later",
+	}).Required()
+)
+
+// GetStandardErrorSchema returns the appropriate standard error schema for a given HTTP status code
+func GetStandardErrorSchema(statusCode int) goop.Schema {
+	switch statusCode {
+	case 400:
+		return BadRequestErrorSchema
+	case 401:
+		return UnauthorizedErrorSchema
+	case 403:
+		return ForbiddenErrorSchema
+	case 404:
+		return NotFoundErrorSchema
+	case 409:
+		return ConflictErrorSchema
+	case 422:
+		return UnprocessableEntityErrorSchema
+	case 429:
+		return TooManyRequestsErrorSchema
+	case 500:
+		return InternalServerErrorSchema
+	case 502:
+		return BadGatewayErrorSchema
+	case 503:
+		return ServiceUnavailableErrorSchema
+	default:
+		// Return generic error schema for unknown status codes
+		return BadRequestErrorSchema
+	}
+}

--- a/operations/multiple_responses_test.go
+++ b/operations/multiple_responses_test.go
@@ -77,6 +77,111 @@ func TestStandardErrorsByCode(t *testing.T) {
 	t.Logf("Defined response codes: %v", getResponseCodes(op.Responses))
 }
 
+func TestErrorSchemaIntegration(t *testing.T) {
+	// Test that error schemas are properly integrated
+	op := NewSimple().
+		POST("/users").
+		WithSuccessResponse(201, validators.String().Required(), "Created").
+		WithBadRequestError(BadRequestErrorSchema).
+		WithUnauthorizedError(UnauthorizedErrorSchema).
+		WithUnprocessableEntityError(ValidationErrorSchema).
+		Handler(nil)
+
+	// Test that schemas are properly set
+	if resp, exists := op.Responses[400]; !exists {
+		t.Error("Expected 400 response to be defined")
+	} else if resp.Schema == nil {
+		t.Error("Expected 400 response to have schema")
+	} else {
+		// Test schema validation with valid error data
+		errorData := map[string]interface{}{
+			"error":   "bad_request",
+			"message": "Invalid request",
+			"code":    400,
+		}
+		if err := resp.Schema.Validate(errorData); err != nil {
+			t.Errorf("Valid error data should pass validation: %v", err)
+		}
+	}
+
+	// Test unprocessable entity error schema specifically
+	if resp, exists := op.Responses[422]; !exists {
+		t.Error("Expected 422 response to be defined")
+	} else if resp.Schema == nil {
+		t.Error("Expected 422 response to have schema")
+	} else {
+		// Test with field validation errors
+		validationData := map[string]interface{}{
+			"error":   "validation_failed",
+			"message": "Request validation failed",
+			"fields": map[string]interface{}{
+				"email": "Invalid email format",
+			},
+		}
+		if err := resp.Schema.Validate(validationData); err != nil {
+			t.Errorf("Valid validation error data should pass: %v", err)
+		}
+	}
+
+	t.Logf("Error schema integration test passed")
+}
+
+func TestGetStandardErrorSchema(t *testing.T) {
+	// Test GetStandardErrorSchema helper function
+	tests := []struct {
+		code     int
+		expected goop.Schema
+	}{
+		{400, BadRequestErrorSchema},
+		{401, UnauthorizedErrorSchema},
+		{403, ForbiddenErrorSchema},
+		{404, NotFoundErrorSchema},
+		{409, ConflictErrorSchema},
+		{422, UnprocessableEntityErrorSchema},
+		{429, TooManyRequestsErrorSchema},
+		{500, InternalServerErrorSchema},
+		{502, BadGatewayErrorSchema},
+		{503, ServiceUnavailableErrorSchema},
+		{999, BadRequestErrorSchema}, // Default case
+	}
+
+	for _, test := range tests {
+		result := GetStandardErrorSchema(test.code)
+		if result != test.expected {
+			t.Errorf("GetStandardErrorSchema(%d) returned unexpected schema", test.code)
+		}
+	}
+}
+
+func TestConvenienceErrorMethods(t *testing.T) {
+	// Test all convenience error methods
+	op := NewSimple().
+		POST("/test").
+		WithSuccessResponse(201, validators.String().Required(), "Created").
+		WithAuthErrors().       // Adds 401, 403
+		WithValidationErrors(). // Adds 400, 422
+		WithCreateErrors().     // Adds 400, 401, 403, 409, 422, 500
+		Handler(nil)
+
+	// All these codes should be present
+	expectedCodes := []int{201, 400, 401, 403, 409, 422, 500}
+	for _, code := range expectedCodes {
+		if _, exists := op.Responses[code]; !exists {
+			t.Errorf("Expected response code %d to be defined after convenience methods", code)
+		}
+	}
+
+	// Test that schemas are properly assigned
+	if resp, exists := op.Responses[401]; exists && resp.Schema == nil {
+		t.Error("Expected 401 response to have schema")
+	}
+	if resp, exists := op.Responses[422]; exists && resp.Schema == nil {
+		t.Error("Expected 422 response to have schema")
+	}
+
+	t.Logf("Convenience methods test passed with codes: %v", getResponseCodes(op.Responses))
+}
+
 // Helper function to get response codes for logging
 func getResponseCodes(responses map[int]goop.ResponseDefinition) []int {
 	codes := make([]int, 0, len(responses))

--- a/operations/multiple_responses_test.go
+++ b/operations/multiple_responses_test.go
@@ -1,0 +1,87 @@
+package operations
+
+import (
+	"testing"
+
+	goop "github.com/picogrid/go-op"
+	"github.com/picogrid/go-op/validators"
+)
+
+func TestMultipleResponsesBuilder(t *testing.T) {
+	// Test WithCreateErrors convenience method
+	op := NewSimple().
+		POST("/test").
+		WithSuccessResponse(201, validators.String().Required(), "Created").
+		WithCreateErrors().
+		Handler(nil)
+
+	// Should have multiple response codes defined
+	if len(op.Responses) == 0 {
+		t.Error("Expected multiple responses to be defined, but got none")
+	}
+
+	// Check specific status codes
+	expectedCodes := []int{201, 400, 401, 403, 409, 422, 500}
+	for _, code := range expectedCodes {
+		if _, exists := op.Responses[code]; !exists {
+			t.Errorf("Expected response code %d to be defined", code)
+		}
+	}
+
+	t.Logf("Defined response codes: %v", getResponseCodes(op.Responses))
+}
+
+func TestMultipleResponsesIndividual(t *testing.T) {
+	// Test individual response definitions
+	op := NewSimple().
+		GET("/test/{id}").
+		WithSuccessResponse(200, validators.String().Required(), "Success").
+		WithBadRequestError(BadRequestErrorSchema).
+		WithNotFoundError(NotFoundErrorSchema).
+		WithServerError(InternalServerErrorSchema).
+		Handler(nil)
+
+	expectedCodes := []int{200, 400, 404, 500}
+	for _, code := range expectedCodes {
+		if _, exists := op.Responses[code]; !exists {
+			t.Errorf("Expected response code %d to be defined", code)
+		}
+	}
+
+	// Verify descriptions are set correctly
+	if resp, exists := op.Responses[200]; !exists || resp.Description != "Success" {
+		t.Error("Expected 200 response with 'Success' description")
+	}
+	if resp, exists := op.Responses[404]; !exists || resp.Description != "Not Found" {
+		t.Error("Expected 404 response with 'Not Found' description")
+	}
+
+	t.Logf("Defined response codes: %v", getResponseCodes(op.Responses))
+}
+
+func TestStandardErrorsByCode(t *testing.T) {
+	// Test WithStandardErrorsByCode
+	op := NewSimple().
+		GET("/test").
+		WithSuccessResponse(200, validators.String().Required(), "OK").
+		WithStandardErrorsByCode(400, 401, 404, 500).
+		Handler(nil)
+
+	expectedCodes := []int{200, 400, 401, 404, 500}
+	for _, code := range expectedCodes {
+		if _, exists := op.Responses[code]; !exists {
+			t.Errorf("Expected response code %d to be defined", code)
+		}
+	}
+
+	t.Logf("Defined response codes: %v", getResponseCodes(op.Responses))
+}
+
+// Helper function to get response codes for logging
+func getResponseCodes(responses map[int]goop.ResponseDefinition) []int {
+	codes := make([]int, 0, len(responses))
+	for code := range responses {
+		codes = append(codes, code)
+	}
+	return codes
+}

--- a/operations/simple_builder.go
+++ b/operations/simple_builder.go
@@ -4,6 +4,13 @@ import (
 	goop "github.com/picogrid/go-op"
 )
 
+// ResponseDefinition represents a response with its schema, description, and optional headers
+type ResponseDefinition struct {
+	Schema      goop.Schema
+	Description string
+	Headers     map[string]goop.Schema
+}
+
 // Core operation configuration struct
 // This contains all the operation metadata and schemas
 type operationConfig struct {
@@ -16,9 +23,10 @@ type operationConfig struct {
 	paramsSchema   goop.Schema
 	querySchema    goop.Schema
 	bodySchema     goop.Schema
-	responseSchema goop.Schema
+	responseSchema goop.Schema // Keep for backward compatibility
 	headerSchema   goop.Schema
 	security       goop.SecurityRequirements
+	responses      map[int]ResponseDefinition // New: Multiple responses support
 }
 
 // Helper method to compile the final operation
@@ -32,6 +40,16 @@ func (config *operationConfig) compile(handler HTTPHandler) CompiledOperation {
 		SuccessCode: config.successCode,
 		Handler:     handler,
 		Security:    config.security,
+		Responses:   make(map[int]goop.ResponseDefinition),
+	}
+
+	// Copy all defined responses
+	for code, response := range config.responses {
+		op.Responses[code] = goop.ResponseDefinition{
+			Schema:      response.Schema,
+			Description: response.Description,
+			Headers:     response.Headers,
+		}
 	}
 
 	// Generate OpenAPI specs if schemas are provided
@@ -81,6 +99,7 @@ func NewSimple() *SimpleOperationBuilder {
 		config: &operationConfig{
 			tags:        []string{},
 			successCode: 200,
+			responses:   make(map[int]ResponseDefinition),
 		},
 	}
 }
@@ -159,10 +178,94 @@ func (s *SimpleOperationBuilder) WithBody(schema goop.Schema) *SimpleOperationBu
 	return s
 }
 
-// WithResponse sets the response schema
+// WithResponse sets the response schema (backward compatibility - maps to 200 response)
 func (s *SimpleOperationBuilder) WithResponse(schema goop.Schema) *SimpleOperationBuilder {
 	s.config.responseSchema = schema
+	// Also add as 200 response for new system
+	s.config.responses[200] = ResponseDefinition{
+		Schema:      schema,
+		Description: "Successful response",
+	}
 	return s
+}
+
+// WithResponseCode sets a response schema for a specific HTTP status code
+func (s *SimpleOperationBuilder) WithResponseCode(code int, schema goop.Schema, description string) *SimpleOperationBuilder {
+	s.config.responses[code] = ResponseDefinition{
+		Schema:      schema,
+		Description: description,
+	}
+	return s
+}
+
+// WithSuccessResponse sets a success response (2xx range)
+func (s *SimpleOperationBuilder) WithSuccessResponse(code int, schema goop.Schema, description string) *SimpleOperationBuilder {
+	if code < 200 || code >= 300 {
+		panic("Success response codes must be in the 2xx range")
+	}
+	return s.WithResponseCode(code, schema, description)
+}
+
+// WithErrorResponse sets an error response (4xx or 5xx range)
+func (s *SimpleOperationBuilder) WithErrorResponse(code int, schema goop.Schema, description string) *SimpleOperationBuilder {
+	if code < 400 {
+		panic("Error response codes must be in the 4xx or 5xx range")
+	}
+	return s.WithResponseCode(code, schema, description)
+}
+
+// Convenience methods for common success responses
+func (s *SimpleOperationBuilder) WithCreatedResponse(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithSuccessResponse(201, schema, "Resource created successfully")
+}
+
+func (s *SimpleOperationBuilder) WithAcceptedResponse(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithSuccessResponse(202, schema, "Request accepted for processing")
+}
+
+func (s *SimpleOperationBuilder) WithNoContentResponse() *SimpleOperationBuilder {
+	return s.WithResponseCode(204, nil, "No content")
+}
+
+// Convenience methods for common error responses
+func (s *SimpleOperationBuilder) WithBadRequestError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(400, schema, "Bad Request")
+}
+
+func (s *SimpleOperationBuilder) WithUnauthorizedError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(401, schema, "Unauthorized")
+}
+
+func (s *SimpleOperationBuilder) WithForbiddenError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(403, schema, "Forbidden")
+}
+
+func (s *SimpleOperationBuilder) WithNotFoundError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(404, schema, "Not Found")
+}
+
+func (s *SimpleOperationBuilder) WithConflictError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(409, schema, "Conflict")
+}
+
+func (s *SimpleOperationBuilder) WithUnprocessableEntityError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(422, schema, "Unprocessable Entity")
+}
+
+func (s *SimpleOperationBuilder) WithTooManyRequestsError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(429, schema, "Too Many Requests")
+}
+
+func (s *SimpleOperationBuilder) WithServerError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(500, schema, "Internal Server Error")
+}
+
+func (s *SimpleOperationBuilder) WithBadGatewayError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(502, schema, "Bad Gateway")
+}
+
+func (s *SimpleOperationBuilder) WithServiceUnavailableError(schema goop.Schema) *SimpleOperationBuilder {
+	return s.WithErrorResponse(503, schema, "Service Unavailable")
 }
 
 // WithHeaders sets the header parameters schema
@@ -220,6 +323,86 @@ func (s *SimpleOperationBuilder) RequireOAuth2(schemeName string, scopes ...stri
 func (s *SimpleOperationBuilder) NoAuth() *SimpleOperationBuilder {
 	s.config.security = goop.NoAuth()
 	return s
+}
+
+// WithCommonErrors adds standard error responses (400, 401, 403, 500) to the operation
+func (s *SimpleOperationBuilder) WithCommonErrors() *SimpleOperationBuilder {
+	return s.
+		WithBadRequestError(BadRequestErrorSchema).
+		WithUnauthorizedError(UnauthorizedErrorSchema).
+		WithForbiddenError(ForbiddenErrorSchema).
+		WithServerError(InternalServerErrorSchema)
+}
+
+// WithAuthErrors adds authentication-related error responses (401, 403) to the operation
+func (s *SimpleOperationBuilder) WithAuthErrors() *SimpleOperationBuilder {
+	return s.
+		WithUnauthorizedError(UnauthorizedErrorSchema).
+		WithForbiddenError(ForbiddenErrorSchema)
+}
+
+// WithValidationErrors adds validation-related error responses (400, 422) to the operation
+func (s *SimpleOperationBuilder) WithValidationErrors() *SimpleOperationBuilder {
+	return s.
+		WithBadRequestError(ValidationErrorSchema).
+		WithUnprocessableEntityError(UnprocessableEntityErrorSchema)
+}
+
+// WithCRUDErrors adds common CRUD operation error responses (400, 401, 403, 404, 500)
+func (s *SimpleOperationBuilder) WithCRUDErrors() *SimpleOperationBuilder {
+	return s.
+		WithBadRequestError(ValidationErrorSchema).
+		WithUnauthorizedError(UnauthorizedErrorSchema).
+		WithForbiddenError(ForbiddenErrorSchema).
+		WithNotFoundError(NotFoundErrorSchema).
+		WithServerError(InternalServerErrorSchema)
+}
+
+// WithCreateErrors adds error responses typical for create operations (400, 401, 403, 409, 422, 500)
+func (s *SimpleOperationBuilder) WithCreateErrors() *SimpleOperationBuilder {
+	return s.
+		WithBadRequestError(ValidationErrorSchema).
+		WithUnauthorizedError(UnauthorizedErrorSchema).
+		WithForbiddenError(ForbiddenErrorSchema).
+		WithConflictError(ConflictErrorSchema).
+		WithUnprocessableEntityError(UnprocessableEntityErrorSchema).
+		WithServerError(InternalServerErrorSchema)
+}
+
+// WithStandardErrorsByCode allows adding multiple standard error responses by status codes
+func (s *SimpleOperationBuilder) WithStandardErrorsByCode(codes ...int) *SimpleOperationBuilder {
+	for _, code := range codes {
+		s.WithErrorResponse(code, GetStandardErrorSchema(code), getStandardErrorDescription(code))
+	}
+	return s
+}
+
+// getStandardErrorDescription returns standard descriptions for HTTP status codes
+func getStandardErrorDescription(code int) string {
+	switch code {
+	case 400:
+		return "Bad Request - The request could not be understood"
+	case 401:
+		return "Unauthorized - Authentication is required"
+	case 403:
+		return "Forbidden - Insufficient permissions"
+	case 404:
+		return "Not Found - The requested resource was not found"
+	case 409:
+		return "Conflict - The request conflicts with current state"
+	case 422:
+		return "Unprocessable Entity - Request contains semantic errors"
+	case 429:
+		return "Too Many Requests - Rate limit exceeded"
+	case 500:
+		return "Internal Server Error - An unexpected error occurred"
+	case 502:
+		return "Bad Gateway - Upstream service unavailable"
+	case 503:
+		return "Service Unavailable - Service temporarily unavailable"
+	default:
+		return "Error"
+	}
 }
 
 // Handler compiles the operation with the provided handler

--- a/scripts/validate-output.sh
+++ b/scripts/validate-output.sh
@@ -101,5 +101,5 @@ echo "   • Order processing (e-commerce, analytics)"
 echo "   • Notification system (messaging, templates)"
 echo "   • Comprehensive schemas with validation"
 echo "   • Path/query/body parameters"
-echo "   • Service-specific tags for organization"
+echo "   • Service-specific tags for structure"
 echo

--- a/types.go
+++ b/types.go
@@ -4,6 +4,13 @@ package goop
 // This is framework-agnostic and can be adapted to any HTTP framework
 type HTTPHandler interface{}
 
+// ResponseDefinition represents a response with its schema, description, and optional headers
+type ResponseDefinition struct {
+	Schema      Schema
+	Description string
+	Headers     map[string]Schema
+}
+
 // CompiledOperation represents a fully compiled operation with all metadata
 // This structure contains everything needed for zero-reflection runtime execution
 type CompiledOperation struct {
@@ -18,15 +25,18 @@ type CompiledOperation struct {
 	ParamsSpec   *OpenAPISchema
 	QuerySpec    *OpenAPISchema
 	BodySpec     *OpenAPISchema
-	ResponseSpec *OpenAPISchema
+	ResponseSpec *OpenAPISchema // Keep for backward compatibility
 	HeaderSpec   *OpenAPISchema
 
 	// Validation schemas for runtime validation
 	ParamsSchema   Schema
 	QuerySchema    Schema
 	BodySchema     Schema
-	ResponseSchema Schema
+	ResponseSchema Schema // Keep for backward compatibility
 	HeaderSchema   Schema
+
+	// Multiple responses support
+	Responses map[int]ResponseDefinition
 
 	// Security requirements for this operation
 	Security SecurityRequirements
@@ -35,7 +45,7 @@ type CompiledOperation struct {
 	// This is framework-specific and should be cast to the appropriate type
 	Handler HTTPHandler
 
-	// Success HTTP status code
+	// Success HTTP status code (backward compatibility)
 	SuccessCode int
 }
 

--- a/validators/composition_impl.go
+++ b/validators/composition_impl.go
@@ -139,14 +139,10 @@ func (c *compositionSchema) validateAllOf(data interface{}) error {
 
 // validateAnyOf ensures at least one schema matches
 func (c *compositionSchema) validateAnyOf(data interface{}) error {
-	var errors []error
-
 	for i, schema := range c.schemas {
 		if validator, ok := schema.(goop.Schema); ok {
 			if err := validator.Validate(data); err == nil {
 				return nil // At least one schema matches
-			} else {
-				errors = append(errors, err)
 			}
 		} else {
 			return goop.NewValidationError("anyOf", data, fmt.Sprintf("schema at index %d does not implement Schema interface", i))


### PR DESCRIPTION
- Introduced a new `error_schemas.go` file with reusable standard error schemas for API responses.
- Added a comprehensive example in `gin-middleware-patterns/main.go` covering global and per-operation middleware with Gin.
- Demonstrated advanced patterns like role-based access control, scope-based permissions, rate limiting, and OpenAPI schema generation.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces reusable error schemas and demonstrates advanced middleware patterns with Gin, including role-based access control and OpenAPI schema generation.
> 
>   - **Error Schemas**:
>     - Introduced `error_schemas.go` with reusable error schemas for API responses.
>     - Includes schemas for common HTTP errors like 400, 401, 403, 404, 409, 422, 429, 500, 502, and 503.
>   - **Middleware Patterns**:
>     - Added `gin-middleware-patterns/main.go` demonstrating middleware patterns with Gin.
>     - Covers global and per-operation middleware, role-based access control, scope-based permissions, and rate limiting.
>     - Demonstrates OpenAPI schema generation.
>   - **Miscellaneous**:
>     - Updated `ast_analyzer.go` to support multiple response codes and error handling.
>     - Modified `generator.go` to handle new response definitions.
>     - Added tests in `middleware_test.go` and `multiple_responses_test.go` for middleware and response handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=picogrid%2Fgo-op&utm_source=github&utm_medium=referral)<sup> for d0aea8122bf52a3c7ee4cefc3c1944286edd51ee. You can [customize](https://app.ellipsis.dev/picogrid/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->